### PR TITLE
Inotify enqueue dirs

### DIFF
--- a/bin/watch
+++ b/bin/watch
@@ -34,11 +34,11 @@ $logger = new class extends AbstractLogger {
 
 $config = new WatcherConfig([$path]);
 $watcher = new PatternMatchingWatcher(new FallbackWatcher([
+    new InotifyWatcher($config, $logger),
     new FindWatcher($config, $logger),
     new PhpPollWatcher($config, $logger),
-    new InotifyWatcher($config, $logger),
     new FsWatchWatcher($config, $logger),
-], $logger), [ '*.php' ]);
+], $logger), [ '/**/*.php' ], []);
 
 Loop::run(function () use ($watcher, $path) {
     $process = yield $watcher->watch([$path]);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ parameters:
     level: 7
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
-        - '{Unable to resolve the template type TReturn in call to function}'
+        - '{Unable to resolve the template type .* in call to function}'
 
     paths:
         - src

--- a/src/Watcher/BufferedWatcher/BufferedWatcher.php
+++ b/src/Watcher/BufferedWatcher/BufferedWatcher.php
@@ -4,7 +4,6 @@ namespace Phpactor\AmpFsWatch\Watcher\BufferedWatcher;
 
 use Amp\Promise;
 use Phpactor\AmpFsWatch\Watcher;
-use Phpactor\AmpFsWatch\WatcherProcess;
 
 class BufferedWatcher implements Watcher
 {

--- a/src/Watcher/BufferedWatcher/BufferedWatcherProcess.php
+++ b/src/Watcher/BufferedWatcher/BufferedWatcherProcess.php
@@ -36,7 +36,8 @@ class BufferedWatcherProcess implements WatcherProcess
 
         \Amp\asyncCall(function () {
             while ($modifiedFile = yield $this->innerProcess->wait()) {
-                $this->buffer[] = $modifiedFile;
+                assert($modifiedFile instanceof ModifiedFile);
+                $this->buffer[$modifiedFile->path()] = $modifiedFile;
             }
         });
     }

--- a/tests/Watcher/BufferedWatcher/BufferedWatcherTest.php
+++ b/tests/Watcher/BufferedWatcher/BufferedWatcherTest.php
@@ -3,7 +3,7 @@
 namespace Phpactor\AmpFsWatcher\Tests\Watcher\BufferedWatcher;
 
 use Amp\PHPUnit\AsyncTestCase;
-use PHPUnit\Framework\TestCase;
+use Generator;
 use Phpactor\AmpFsWatch\ModifiedFile;
 use Phpactor\AmpFsWatch\ModifiedFileQueue;
 use Phpactor\AmpFsWatch\Watcher\BufferedWatcher\BufferedWatcher;
@@ -11,7 +11,7 @@ use Phpactor\AmpFsWatch\Watcher\TestWatcher\TestWatcher;
 
 class BufferedWatcherTest extends AsyncTestCase
 {
-    public function testBufferedWatcher()
+    public function testBufferedWatcher(): Generator
     {
         $expectedFile1 = new ModifiedFile('/foo', ModifiedFile::TYPE_FILE);
         $expectedFile2 = new ModifiedFile('/bar', ModifiedFile::TYPE_FILE);
@@ -26,5 +26,26 @@ class BufferedWatcherTest extends AsyncTestCase
 
         self::assertSame($expectedFile1, $file1);
         self::assertSame($expectedFile2, $file2);
+    }
+
+    public function testDeduplicatesFiles(): Generator
+    {
+        $expectedFile1 = new ModifiedFile('/foo', ModifiedFile::TYPE_FILE);
+        $expectedFile2 = new ModifiedFile('/foo', ModifiedFile::TYPE_FILE);
+        $expectedFile3 = new ModifiedFile('/bar', ModifiedFile::TYPE_FILE);
+        $expectedFile4 = new ModifiedFile('/bar', ModifiedFile::TYPE_FILE);
+        $queue = new ModifiedFileQueue([
+            $expectedFile4,
+            $expectedFile3,
+            $expectedFile2,
+            $expectedFile1,
+        ]);
+        $bufferedWatcher = new BufferedWatcher(new TestWatcher($queue), 100);
+        $process = yield $bufferedWatcher->watch();
+        $file1 = yield $process->wait();
+        $file2 = yield $process->wait();
+
+        self::assertSame($expectedFile2, $file1);
+        self::assertSame($expectedFile4, $file2);
     }
 }

--- a/tests/Watcher/WatcherTestCase.php
+++ b/tests/Watcher/WatcherTestCase.php
@@ -179,7 +179,7 @@ abstract class WatcherTestCase extends IntegrationTestCase
      *
      * @return Promise<WatcherProcess>
      */
-    private function startProcess(?array $paths = []): Promise
+    protected function startProcess(?array $paths = []): Promise
     {
         $paths = $paths ?: [ $this->workspace()->path() ];
         $watcher = $this->createWatcher(new WatcherConfig($paths));


### PR DESCRIPTION
Inotify does not register individual files when a folder is moved within the watched directory (which is important because `composer` moves it's packages from temporary directories on install).

This PR will cause the Inotify watcher to yield all files in the moved directory.