### PR TITLE
Make the use of POSIX signals optional

### DIFF
--- a/bin/watch
+++ b/bin/watch
@@ -47,8 +47,11 @@ Loop::run(function () use ($watcher, $path) {
         fwrite(STDOUT, sprintf('[%s] %s (%s)'."\n", date('Y-m-d H:i:s.u'), $file->path(), $file->type()));
     }
 
-    Loop::onSignal(SIGINT, function () use ($process) {
-        $process->stop();
-        Loop::stop();
-    });
+    // Signals are not supported on Windows
+    if(defined('SIGINT')) {
+        Loop::onSignal(SIGINT, function () use ($process) {
+            $process->stop();
+            Loop::stop();
+        });
+    }
 });


### PR DESCRIPTION
Signals are not supported on Windows, and gracefully shutting down everything doesn't seem necessary if we're about to exit anyway.